### PR TITLE
Added a default keymap compatiable with updated module 

### DIFF
--- a/config/keyboardio_preonic.keymap
+++ b/config/keyboardio_preonic.keymap
@@ -9,75 +9,82 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
-#define PREONIC_ORTHO   1
-// #define PREONIC_MIT     1
-
-#define NAV_L 1
-#define NUM_L 2
-#define SYM_L 3
+#define LOWER 1
+#define RAISE 2
+#define FN 3
 
 // Using layer taps on thumbs, having quick tap as well helps w/ repeating space/backspace
 &lt { quick_tap_ms = <200>; };
 
+// Convenience macro to make the Bluetooth commands shorter
 #define BT(n) BT_SEL n
 
+// Hyper key: all the modifiers
+#define HYPER LC(LS(LA(LGUI)))
+
 / {
-#if defined(PREONIC_ORTHO)
     chosen {
-       zmk,matrix_transform = &ortho_transform;
+        // Valid choices: [ &mit_layout, &ortho_layout ]
+        zmk,physical-layout = &mit_layout;
     };
-#endif
-    
+
     keymap {
         compatible = "zmk,keymap";
 
         base_layer {
             label = "Base";
             bindings = <
-		                                                                                          &kp X &kp Y &kp Z
- &kp ESC    &kp N1      &kp N2      &kp N3       &kp N4          &kp N5          &kp N6            &kp N7          &kp N8       &kp N9      &kp N0         &kp DEL
- &kp TAB    &kp Q      &kp W      &kp E       &kp R          &kp T          &kp Y            &kp U          &kp I       &kp O      &kp P         &kp BKSP
- &gresc    &kp A      &kp S      &kp D       &kp F          &kp G          &kp H            &kp J          &kp K       &kp L      &kp SEMI      &kp QUOT
- &kp LSHFT  &kp Z      &kp X      &kp C       &kp V          &kp B          &kp N            &kp M          &kp COMMA   &kp DOT    &kp FSLH      &kp RET
-#if defined(PREONIC_ORTHO)
- &kp LCTRL  &mo SYM_L   &kp LGUI  &kp LALT    &mo NAV_L      &kp SPACE      &kp RET          &mo NUM_L      &kp LEFT    &kp UP     &kp DOWN      &kp RIGHT
-#else
- &kp LCTRL  &mo SYM_L   &kp LGUI  &kp LALT    &mo NAV_L          &kp SPACE                   &mo NUM_L      &kp LEFT    &kp UP     &kp DOWN      &kp RIGHT
-#endif
+                                                                                                             &kp X       &mo FN      &kp Z
+
+ &kp GRAVE   &kp N1      &kp N2      &kp N3      &kp N4      &kp N5      &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &kp MINUS
+ &kp TAB     &kp Q       &kp W       &kp E       &kp R       &kp T       &kp Y       &kp U       &kp I       &kp O       &kp P       &kp BKSP
+ &kp ESC     &kp A       &kp S       &kp D       &kp F       &kp G       &kp H       &kp J       &kp K       &kp L       &kp SEMI    &kp SQT
+ &kp LSHFT   &kp Z       &kp X       &kp C       &kp V       &kp B       &kp N       &kp M       &kp COMMA   &kp PERIOD  &kp SLASH   &kp ENTER
+ &kp HYPER   &kp LCTRL   &kp LALT    &kp LGUI    &mo LOWER         &kp SPACE         &mo RAISE   &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT
+
             >;
         };
 
-        nav_layer {
-            label = "Nav";
+        lower_layer {
+            label = "Lower";
             bindings = <
-		                                                                                          &trans &trans &trans
-&trans &trans     &trans     &trans      &trans          &trans       &trans     &trans         &trans      &trans     &trans     &trans
-&bt BT_CLR &trans     &trans     &trans      &trans          &trans       &trans     &trans         &trans      &trans     &trans     &kp DEL
-&trans     &trans     &trans     &trans      &trans          &trans       &trans     &kp LEFT       &kp DOWN    &kp UP     &kp RIGHT  &trans
-&trans     &bt BT(0)  &bt BT(1)  &bt BT(2)   &bt BT(3)       &bt BT(4)    &trans     &kp HOME       &kp PG_DN   &kp PG_UP  &kp END    &trans
-#if defined(PREONIC_ORTHO)
-&trans  &trans       &trans     &trans      &trans    &trans         &trans     &trans        &trans      &trans &trans &trans
-#else
-&trans  &trans       &trans     &trans      &trans           &trans            &trans        &trans      &trans &trans &trans
-#endif
+                                                                                                               &trans          &trans       &trans
+
+ &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans      &kp KP_DIVIDE &kp KP_MULTIPLY &kp KP_MINUS &kp KP_EQUAL
+ &trans      &trans      &trans      &trans      &trans      &trans      &trans      &kp KP_N7   &kp KP_N8     &kp KP_N9       &kp KP_MINUS &trans
+ &trans      &trans      &trans      &trans      &trans      &trans      &trans      &kp KP_N4   &kp KP_N5     &kp KP_N6       &kp KP_PLUS  &trans
+ &trans      &trans      &trans      &trans      &trans      &trans      &trans      &kp KP_N1   &kp KP_N2     &kp KP_N3       &kp KP_PLUS  &trans
+ &trans      &trans      &trans      &trans      &trans            &kp BKSP          &kp KP_N0   &kp KP_DOT    &trans          &kp KP_ENTER &trans
+
             >;
         };
 
-        num_layer {
-            label = "Num";
+        raise_layer {
+            label = "Raise";
             bindings = <
-		                                                                                          &trans &trans &trans
-&trans &trans     &trans     &trans      &trans          &trans       &trans     &trans         &trans      &trans     &trans     &trans
-&trans     &kp LBKT   &trans &trans &trans    &kp RBKT    &kp C_PREV    &kp N7     &kp N8      &kp N9       &trans     &trans
-&trans     &kp MINUS  &trans &trans &trans    &kp EQUAL   &kp C_NEXT    &kp N4     &kp N5      &kp N6       &trans     &trans
-&trans     &kp GRAVE  &trans &trans &trans    &kp BSLH    &trans        &kp N1     &kp N2      &kp N3       &trans     &trans
-#if defined(PREONIC_ORTHO)
-&trans  &trans       &trans     &kp N0      &trans    &none         &none     &kp ESC        &kp DEL      &trans &trans &trans
-#else
-&trans  &trans       &trans     &kp N0      &trans           &none            &trans        &kp DEL      &trans &trans &trans
-#endif
+                                                                                                               &trans     &trans     &trans
+
+ &kp ESC     &kp F1      &kp F2      &kp F3      &kp F4      &kp F5      &kp F6      &kp F7       &kp F8       &kp F9     &kp F10    &kp BKSP
+ &trans      &trans      &trans      &trans      &trans      &trans      &kp BSLH    &kp LS(LBKT) &kp LS(RBKT) &kp LBKT   &kp RBKT   &kp DEL
+ &kp CAPS    &trans      &trans      &trans      &trans      &trans      &kp LEFT    &kp DOWN     &kp UP       &kp RIGHT  &trans     &trans
+ &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans       &trans       &trans     &trans     &trans
+ &trans      &trans      &kp RALT    &trans      &trans            &trans            &trans       &trans       &trans     &trans     &trans
+
+            >;
+        };
+
+        func_layer {
+            label = "Function";
+            bindings = <
+                                                                                                             &trans      &trans      &trans
+
+ &out OUT_TOG &bt BT(0)   &bt BT(1)   &bt BT(2)   &bt BT(3)   &bt BT(4)   &trans      &trans      &trans     &trans      &trans      &trans
+ &trans       &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans     &trans      &trans      &trans
+ &trans       &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans     &trans      &trans      &trans
+ &trans       &trans      &trans      &trans      &trans      &trans      &trans      &trans      &trans     &trans      &trans      &trans
+ &bootloader  &trans      &trans      &trans      &studio_unlock    &trans            &trans      &trans     &trans      &trans      &bt BT_CLR
+
             >;
         };
     };
 };
-

--- a/config/keyboardio_preonic.keymap
+++ b/config/keyboardio_preonic.keymap
@@ -34,7 +34,7 @@
         base_layer {
             label = "Base";
             bindings = <
-                                                                                                             &kp X       &mo FN      &kp Z
+                                                                                                             &kp C_PP    &mo FN      &kp C_MUTE
 
  &kp GRAVE   &kp N1      &kp N2      &kp N3      &kp N4      &kp N5      &kp N6      &kp N7      &kp N8      &kp N9      &kp N0      &kp MINUS
  &kp TAB     &kp Q       &kp W       &kp E       &kp R       &kp T       &kp Y       &kp U       &kp I       &kp O       &kp P       &kp BKSP
@@ -43,6 +43,7 @@
  &kp HYPER   &kp LCTRL   &kp LALT    &kp LGUI    &mo LOWER         &kp SPACE         &mo RAISE   &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT
 
             >;
+            sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;            
         };
 
         lower_layer {
@@ -57,6 +58,7 @@
  &trans      &trans      &trans      &trans      &trans            &kp BKSP          &kp KP_N0   &kp KP_DOT    &trans          &kp KP_ENTER &trans
 
             >;
+            sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
         };
 
         raise_layer {
@@ -71,6 +73,7 @@
  &trans      &trans      &kp RALT    &trans      &trans            &trans            &trans       &trans       &trans     &trans     &trans
 
             >;
+            sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
         };
 
         func_layer {
@@ -85,6 +88,7 @@
  &bootloader  &trans      &trans      &trans      &studio_unlock    &trans            &trans      &trans     &trans      &trans      &bt BT_CLR
 
             >;
+            sensor-bindings = <&inc_dec_kp C_VOLUME_UP C_VOLUME_DOWN>;
         };
     };
 };


### PR DESCRIPTION
This PR contains a key updated keymap that was copied from the updated module with studio. The keymap was initially updated by @replicaJunction in the module repo, then copied and edited by me to include an encoder mapping + changing the "Any" button to be a play pause.

This default keymap in the zmk config repo is a nice to have convenience  so that users will not have to define layouts themselves. And without this layout, the Github actions would fail due to the studio feature requiring it.